### PR TITLE
feature: allow specifying raw command

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,22 +1,6 @@
 name: Linux
 
-on:
-  push:
-    branches:
-      - master
-      - beta
-      - stable
-    tags-ignore:
-      - "**"
-    paths-ignore:
-      - "**.md"
-      - "**.yaml"
-      - "**.yml"
-  pull_request:
-    paths-ignore:
-      - "**.md"
-      - "**.yaml"
-      - "**.yml"
+on: [push, pull_request]
 
 jobs:
   golang:
@@ -48,4 +32,4 @@ jobs:
         run: go mod download
 
       - name: Run golang tests with coverage
-        run: make test
+        run: make testpkg

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,9 @@ linters-settings:
   nolintlint:
     allow-leading-space: false
     require-specific: true
+  gosec:
+    excludes:
+      - G204
 
 linters: # All available linters list: <https://golangci-lint.run/usage/linters/>
   disable-all: true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["Configurer"]
+  "cSpell.words": ["Configurer", "mapstructure"]
 }

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
-test:
+testpkg:
 	go test -v -race -cover -tags=debug ./...

--- a/config.go
+++ b/config.go
@@ -11,27 +11,20 @@ import (
 type Config struct {
 	// OnInit configuration
 	OnInit *InitConfig `mapstructure:"on_init"`
-
 	// AfterInit command to run after pool initialization
 	AfterInit *InitConfig `mapstructure:"after_init"`
-
 	// Command to run as application.
-	Command string `mapstructure:"command"`
-
+	Command []string `mapstructure:"command"`
 	// User to run application under.
 	User string `mapstructure:"user"`
-
 	// Group to run application under.
 	Group string `mapstructure:"group"`
-
 	// Env represents application environment.
 	Env map[string]string `mapstructure:"env"`
-
 	// Relay defines connection method and factory to be used to connect to workers:
 	// "pipes", "tcp://:6001", "unix://rr.sock"
 	// This config section must not change on re-configuration.
 	Relay string `mapstructure:"relay"`
-
 	// RelayTimeout defines for how long socket factory will be waiting for worker connection. This config section
 	// must not change on re-configuration. Defaults to 60s.
 	RelayTimeout time.Duration `mapstructure:"relay_timeout"`
@@ -39,11 +32,9 @@ type Config struct {
 
 type InitConfig struct {
 	// Command which is started before worker starts
-	Command string `mapstructure:"command"`
-
+	Command []string `mapstructure:"command"`
 	// ExecTimeout is execute timeout for the command
 	ExecTimeout time.Duration `mapstructure:"exec_timeout"`
-
 	// Env represents application environment.
 	Env map[string]string `mapstructure:"env"`
 }
@@ -56,7 +47,7 @@ type RPCConfig struct {
 
 // InitDefaults for the server config
 func (cfg *Config) InitDefaults() error {
-	if cfg.Command == "" {
+	if len(cfg.Command) == 0 {
 		return errors.Str("command should not be empty")
 	}
 
@@ -69,7 +60,7 @@ func (cfg *Config) InitDefaults() error {
 	}
 
 	if cfg.AfterInit != nil {
-		if cfg.AfterInit.Command == "" {
+		if len(cfg.AfterInit.Command) == 0 {
 			return errors.Str("after_init command should not be empty")
 		}
 
@@ -79,7 +70,7 @@ func (cfg *Config) InitDefaults() error {
 	}
 
 	if cfg.OnInit != nil {
-		if cfg.OnInit.Command == "" {
+		if len(cfg.OnInit.Command) == 0 {
 			return errors.Str("on_init command should not be empty")
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/roadrunner-server/errors v1.2.0
-	github.com/roadrunner-server/sdk/v4 v4.4.0-beta.4
+	github.com/roadrunner-server/sdk/v4 v4.4.0-beta.5
 	github.com/spf13/viper v1.16.0
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.25.0

--- a/go.sum
+++ b/go.sum
@@ -153,10 +153,8 @@ github.com/roadrunner-server/errors v1.2.0 h1:qBmNXt8Iex9QnYTjCkbJKsBZu2EtYkQCM0
 github.com/roadrunner-server/errors v1.2.0/go.mod h1:z0ECxZp/dDa5RahtMcy4mBIavVxiZ9vwE5kByl7kFtY=
 github.com/roadrunner-server/goridge/v3 v3.6.3 h1:8hCuPVK9BxIE4IGyNphK6KPAy9Kg6t5tHaItBIQKh2o=
 github.com/roadrunner-server/goridge/v3 v3.6.3/go.mod h1:hB5+lHhl8msuHrngjKQ+Wx8B705AU0/2DlYGFXbjtgU=
-github.com/roadrunner-server/sdk/v4 v4.4.0-beta.3 h1:XBMmlRf7JhXMjkuhuY5VWhoqhHcFtEkPP4BbmEtGy6A=
-github.com/roadrunner-server/sdk/v4 v4.4.0-beta.3/go.mod h1:QcZBTccDGT8zhbHkbzqM7SORktVtvh6Jigkz3hy6kBk=
-github.com/roadrunner-server/sdk/v4 v4.4.0-beta.4 h1:DtHQBo9xXdN5ru2GAf8tCGnwxLG6lgknzYaDr+c3Fv4=
-github.com/roadrunner-server/sdk/v4 v4.4.0-beta.4/go.mod h1:QcZBTccDGT8zhbHkbzqM7SORktVtvh6Jigkz3hy6kBk=
+github.com/roadrunner-server/sdk/v4 v4.4.0-beta.5 h1:+CmSTbz+y51auBr48ldwx6ZgAnWKl7f3537xyW8GDsU=
+github.com/roadrunner-server/sdk/v4 v4.4.0-beta.5/go.mod h1:UkiAk5IdmUzkXncfy671OoH6i/zWpWc+JY3IU/AnQuc=
 github.com/roadrunner-server/tcplisten v1.3.0 h1:VDd6IbP8oIjm5vKvMVozeZgeHgOcoP0XYLOyOqcZHCY=
 github.com/roadrunner-server/tcplisten v1.3.0/go.mod h1:VR6Ob5am0oEuLMOeLiVvQxG9ShykAEgrlvZddX8EfoU=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -33,7 +33,7 @@ func TestCommandUnknownUser(t *testing.T) {
 			log:          log,
 		}
 
-		_ = p.customCmd(nil)("php foo/bar")
+		_ = p.customCmd(nil)([]string{"php foo/bar"})
 	})
 }
 
@@ -45,7 +45,7 @@ func TestCommand1(t *testing.T) {
 		log:          log,
 	}
 
-	cmd := p.customCmd(nil)("php foo/bar")
+	cmd := p.customCmd(nil)([]string{"php foo/bar"})
 	require.Equal(t, "php", cmd.Args[0])
 	require.Equal(t, "foo/bar", cmd.Args[1])
 }
@@ -58,10 +58,36 @@ func TestCommand2(t *testing.T) {
 		log:          log,
 	}
 
-	cmd := p.customCmd(nil)("php foo bar")
+	cmd := p.customCmd(nil)([]string{"php foo bar"})
 	require.Equal(t, "php", cmd.Args[0])
 	require.Equal(t, "foo", cmd.Args[1])
 	require.Equal(t, "bar", cmd.Args[2])
+}
+
+func TestCommand3(t *testing.T) {
+	log, _ := zap.NewDevelopment()
+	p := &Plugin{
+		preparedEnvs: make([]string, 0),
+		cfg:          &Config{},
+		log:          log,
+	}
+
+	cmd := p.customCmd(nil)([]string{"php", "foo/bar"})
+	require.Equal(t, "php", cmd.Args[0])
+	require.Equal(t, "foo/bar", cmd.Args[1])
+}
+
+func TestCommand4_spaces(t *testing.T) {
+	log, _ := zap.NewDevelopment()
+	p := &Plugin{
+		preparedEnvs: make([]string, 0),
+		cfg:          &Config{},
+		log:          log,
+	}
+
+	cmd := p.customCmd(nil)([]string{"/Application Support/folder/php", "foo/bar"})
+	require.Equal(t, "/Application Support/folder/php", cmd.Args[0])
+	require.Equal(t, "foo/bar", cmd.Args[1])
 }
 
 func TestEnv(t *testing.T) {


### PR DESCRIPTION
# Reason for This PR

closes: https://github.com/roadrunner-server/roadrunner/issues/1667

## Description of Changes

- Allow raw command with `[]string` of command parts. There are no breaking changes for config or RR. Command (for `server.command`, `server.on_init`, `server.after_init`, `pool.command`, `pool.after_init`) can be specified as `string` or `array` where the 0-th element of the array is executable and all other arguments are passed to the executable (binary).

Configuration sample:

```yaml
server:
  command: ["/Application Support/php", "../rr-e2e-tests/php_test_files/php-test.php"]
  relay: pipes
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
