### PR TITLE
Add `user` param to `on_init` command section

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,6 +35,8 @@ type InitConfig struct {
 	ExecTimeout time.Duration `mapstructure:"exec_timeout"`
 	// Env represents application environment.
 	Env map[string]string `mapstructure:"env"`
+	// Env represents UID
+	User string `mapstructure:"user"`
 }
 
 // RPCConfig should be in sync with rpc/config.go

--- a/plugin.go
+++ b/plugin.go
@@ -159,7 +159,7 @@ func (p *Plugin) Serve() chan error {
 	errCh := make(chan error, 1)
 
 	if p.cfg.OnInit != nil {
-		err := newCommand(p.log, p.cfg.OnInit.Env, p.cfg.OnInit.Command, p.cfg.OnInit.ExecTimeout).start()
+		err := newCommand(p.log, p.cfg.OnInit).start()
 		if err != nil {
 			p.log.Error("on_init was finished with errors", zap.Error(err))
 		}


### PR DESCRIPTION
# Reason for This PR

closes: https://github.com/roadrunner-server/roadrunner/issues/1585

## Description of Changes

Added abillity to configure `user` for `on_init` command section.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new user configuration option for initialization settings.
  
- **Refactor**
  - Streamlined command initialization by incorporating a unified configuration structure.
  - Simplified the command setup process in plugins with consolidated configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->