### PR TITLE
chore: simplify, modernize (Go 1.26), update deps

### DIFF
--- a/init.go
+++ b/init.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -38,12 +37,14 @@ func (b *command) start() error {
 		}
 	}
 
-	timer := time.NewTimer(b.cfg.ExecTimeout)
-
 	err := cmd.Start()
 	if err != nil {
 		return errors.E(op, err)
 	}
+
+	// Start the timer only after the process has launched successfully.
+	timer := time.NewTimer(b.cfg.ExecTimeout)
+	defer timer.Stop()
 
 	go func() {
 		errW := cmd.Wait()
@@ -71,7 +72,6 @@ func (b *command) start() error {
 		return nil
 
 	case err := <-stopCh:
-		timer.Stop()
 		return err
 	}
 }
@@ -83,38 +83,23 @@ func (b *command) Write(data []byte) (int, error) {
 
 // create command for the process
 func (b *command) createProcess(env map[string]string, cmd []string) *exec.Cmd {
-	// cmdArgs contain command arguments if the command in the form of: php <command> or ls <command> -i -b
-	var cmdArgs []string
+	cmdArgs := prepareCmd(cmd)
+
 	var execCmd *exec.Cmd
-
-	// TODO!: better way to handle commands, we should not use strings.Split based on space
-	// here we may have 2 cases: command declared as a space-separated string or as a slice
-	switch len(cmd) {
-	// command defined as a space-separated string
-	case 1:
-		// we know that the len is 1, so we can safely use the first element
-		cmdArgs = append(cmdArgs, strings.Split(cmd[0], " ")...)
-	default:
-		// we have a slice with 2 or more elements
-		// first element is the command, the rest are arguments
-		cmdArgs = cmd
-	}
-
 	if len(cmdArgs) == 1 {
-		execCmd = exec.CommandContext(context.Background(), cmd[0])
+		execCmd = exec.CommandContext(context.Background(), cmdArgs[0])
 	} else {
 		execCmd = exec.CommandContext(context.Background(), cmdArgs[0], cmdArgs[1:]...)
 	}
 
+	// OS env first, then config env so that user config takes precedence.
+	execCmd.Env = append(os.Environ(), execCmd.Env...)
+
 	// set env variables from the config
-	if len(env) > 0 {
-		for k, v := range env {
-			execCmd.Env = append(execCmd.Env, fmt.Sprintf("%s=%s", strings.ToUpper(k), os.Expand(v, os.Getenv)))
-		}
+	for k, v := range env {
+		execCmd.Env = append(execCmd.Env, strings.ToUpper(k)+"="+os.ExpandEnv(v))
 	}
 
-	// append system envs
-	execCmd.Env = append(execCmd.Env, os.Environ()...)
 	// redirect stderr and stdout into the Write function of the process.go
 	execCmd.Stderr = b
 	execCmd.Stdout = b

--- a/internal.go
+++ b/internal.go
@@ -26,7 +26,7 @@ type internalCmdWithArgs func(command []string) *exec.Cmd
 // slice is used as-is.
 func prepareCmd(command []string) []string {
 	if len(command) == 1 {
-		return strings.Split(command[0], " ")
+		return strings.Fields(command[0])
 	}
 	return command
 }

--- a/internal.go
+++ b/internal.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"slices"
 	"strings"
 
 	"github.com/roadrunner-server/errors"
@@ -20,6 +21,16 @@ type internalCommand func() *exec.Cmd
 // should be the same as pool.Command
 type internalCmdWithArgs func(command []string) *exec.Cmd
 
+// prepareCmd normalises a command slice: a single-element slice whose value is
+// a space-separated string is split into individual arguments; a multi-element
+// slice is used as-is.
+func prepareCmd(command []string) []string {
+	if len(command) == 1 {
+		return strings.Split(command[0], " ")
+	}
+	return command
+}
+
 // cmdFactory provides worker command factory associated with given context
 func (p *Plugin) cmdFactory(env map[string]string) internalCommand {
 	return func() *exec.Cmd {
@@ -32,14 +43,11 @@ func (p *Plugin) cmdFactory(env map[string]string) internalCommand {
 		}
 
 		// copy prepared envs
-		cmd.Env = make([]string, len(p.preparedEnvs))
-		copy(cmd.Env, p.preparedEnvs)
+		cmd.Env = slices.Clone(p.preparedEnvs)
 
 		// append external envs
-		if len(env) > 0 {
-			for k, v := range env {
-				cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", strings.ToUpper(k), v))
-			}
+		for k, v := range env {
+			cmd.Env = append(cmd.Env, strings.ToUpper(k)+"="+v)
 		}
 
 		process.IsolateProcess(cmd)
@@ -56,7 +64,7 @@ func (p *Plugin) cmdFactory(env map[string]string) internalCommand {
 	}
 }
 
-// customCmd used as and enhancement for the CmdFactory to use with a custom command string (used by default)
+// customCmd used as an enhancement for the CmdFactory to use with a custom command string (used by default)
 func (p *Plugin) customCmd(env map[string]string) internalCmdWithArgs {
 	return func(command []string) *exec.Cmd {
 		// if no command provided, use the server's one
@@ -64,21 +72,9 @@ func (p *Plugin) customCmd(env map[string]string) internalCmdWithArgs {
 			command = p.cfg.Command
 		}
 
+		preparedCmd := prepareCmd(command)
+
 		var cmd *exec.Cmd
-
-		preparedCmd := make([]string, 0, 5)
-		// here we may have 2 cases: command declared as a space-separated string or as a slice
-		switch len(command) {
-		// command defined as a space-separated string
-		case 1:
-			// we know that the len is 1, so we can safely use the first element
-			preparedCmd = append(preparedCmd, strings.Split(command[0], " ")...)
-		default:
-			// we have a slice with 2 or more elements
-			// first element is the command, the rest are arguments
-			preparedCmd = command
-		}
-
 		if len(preparedCmd) == 1 {
 			cmd = exec.CommandContext(context.Background(), preparedCmd[0])
 		} else {
@@ -86,14 +82,11 @@ func (p *Plugin) customCmd(env map[string]string) internalCmdWithArgs {
 		}
 
 		// copy prepared envs
-		cmd.Env = make([]string, len(p.preparedEnvs))
-		copy(cmd.Env, p.preparedEnvs)
+		cmd.Env = slices.Clone(p.preparedEnvs)
 
 		// append external envs
-		if len(env) > 0 {
-			for k, v := range env {
-				cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", strings.ToUpper(k), v))
-			}
+		for k, v := range env {
+			cmd.Env = append(cmd.Env, strings.ToUpper(k)+"="+v)
 		}
 
 		process.IsolateProcess(cmd)
@@ -117,8 +110,8 @@ func initFactory(log *slog.Logger, relay string) (pool.Factory, error) {
 		return pipe.NewPipeFactory(log), nil
 	}
 
-	dsn := strings.Split(relay, delim)
-	if len(dsn) != 2 {
+	network, _, ok := strings.Cut(relay, delim)
+	if !ok {
 		return nil, errors.E(op, errors.Network, errors.Str("invalid DSN (tcp://:6001, unix://file.sock)"))
 	}
 
@@ -127,11 +120,8 @@ func initFactory(log *slog.Logger, relay string) (pool.Factory, error) {
 		return nil, errors.E(op, errors.Network, err)
 	}
 
-	switch dsn[0] {
-	// sockets group
-	case unix:
-		return socket.NewSocketServer(lsn, log), nil
-	case tcp:
+	switch network {
+	case unix, tcp:
 		return socket.NewSocketServer(lsn, log), nil
 	default:
 		return nil, errors.E(op, errors.Network, errors.Str("invalid DSN (tcp://:6001, unix://file.sock)"))

--- a/plugin.go
+++ b/plugin.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 	"os/user"
@@ -52,34 +51,21 @@ func (p *Plugin) Init(cfg Configurer, log NamedLogger) error {
 		return errors.E(op, errors.Init, err)
 	}
 
-	p.log = new(slog.Logger)
 	p.log = log.NamedLogger(PluginName)
 
-	// here we may have 2 cases: command declared as a space-separated string or as a slice
-	switch len(p.cfg.Command) {
-	// command defined as a space-separated string
-	case 1:
-		// we know that the len is 1, so we can safely use the first element
-		p.preparedCmd = append(p.preparedCmd, strings.Split(p.cfg.Command[0], " ")...)
-	default:
-		// we have a slice with a 2 or more elements
-		// first element is the command, the rest are arguments
-		p.preparedCmd = p.cfg.Command
-	}
+	p.preparedCmd = prepareCmd(p.cfg.Command)
 
-	p.preparedEnvs = append(os.Environ(), fmt.Sprintf(RrRelay+"=%s", p.cfg.Relay))
+	p.preparedEnvs = append(os.Environ(), RrRelay+"="+p.cfg.Relay)
 	if p.rpcCfg != nil && p.rpcCfg.Listen != "" {
-		p.preparedEnvs = append(p.preparedEnvs, fmt.Sprintf("%s=%s", RrRPC, p.rpcCfg.Listen))
+		p.preparedEnvs = append(p.preparedEnvs, RrRPC+"="+p.rpcCfg.Listen)
 	}
 
 	// set env variables from the config
-	if len(p.cfg.Env) > 0 {
-		for k, v := range p.cfg.Env {
-			p.preparedEnvs = append(p.preparedEnvs, fmt.Sprintf("%s=%s", strings.ToUpper(k), os.Expand(v, os.Getenv)))
-		}
+	for k, v := range p.cfg.Env {
+		p.preparedEnvs = append(p.preparedEnvs, strings.ToUpper(k)+"="+os.ExpandEnv(v))
 	}
 
-	p.preparedEnvs = append(p.preparedEnvs, fmt.Sprintf("%s=%s", RrVersion, cfg.RRVersion()))
+	p.preparedEnvs = append(p.preparedEnvs, RrVersion+"="+cfg.RRVersion())
 
 	p.factory, err = initFactory(p.log, p.cfg.Relay)
 	if err != nil {
@@ -160,44 +146,41 @@ func (p *Plugin) NewPoolWithOptions(ctx context.Context, cfg *pool.Config, env m
 	return pl, nil
 }
 
-// UID returns a user id (if specified by user)
-func (p *Plugin) UID() int {
+// userInfo looks up the user once and returns uid and gid as ints.
+func (p *Plugin) userInfo() (uid int, gid int) {
 	if p.cfg.User == "" {
-		return 0
+		return 0, 0
 	}
 
 	usr, err := user.Lookup(p.cfg.User)
 	if err != nil {
 		p.log.Error("failed to get user", "id", p.cfg.User)
-		return 0
+		return 0, 0
 	}
 
-	usrI32, err := strconv.ParseInt(usr.Uid, 10, 32)
+	uid, err = strconv.Atoi(usr.Uid)
 	if err != nil {
 		p.log.Error("failed to parse user id", "id", p.cfg.User)
-		return 0
+		return 0, 0
 	}
 
-	return int(usrI32)
+	gid, err = strconv.Atoi(usr.Gid)
+	if err != nil {
+		p.log.Error("failed to parse group id", "id", p.cfg.User)
+		return 0, 0
+	}
+
+	return uid, gid
+}
+
+// UID returns a user id (if specified by user)
+func (p *Plugin) UID() int {
+	uid, _ := p.userInfo()
+	return uid
 }
 
 // GID returns a group id (if specified by user)
 func (p *Plugin) GID() int {
-	if p.cfg.User == "" {
-		return 0
-	}
-
-	usr, err := user.Lookup(p.cfg.User)
-	if err != nil {
-		p.log.Error("failed to get user", "id", p.cfg.User)
-		return 0
-	}
-
-	grI32, err := strconv.ParseInt(usr.Gid, 10, 32)
-	if err != nil {
-		p.log.Error("failed to parse group id", "id", p.cfg.Group)
-		return 0
-	}
-
-	return int(grI32)
+	_, gid := p.userInfo()
+	return gid
 }

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -157,7 +157,9 @@ go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhO
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
 go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
 go.opentelemetry.io/otel/sdk v1.44.0 h1:nHYwb9lK+fJPU/dnT6s7W7Z8itMWyqrnVfbheVYrZ58=
+go.opentelemetry.io/otel/sdk v1.44.0/go.mod h1:Osuydd3Se74nqjAKxid74N5eC+jfEqfTegHRnq58oK0=
 go.opentelemetry.io/otel/sdk/metric v1.44.0 h1:3LlKgI+VjbVsjNRFZJZAJ30WjXC5VkNRks6si09iEfI=
+go.opentelemetry.io/otel/sdk/metric v1.44.0/go.mod h1:5B5pMARnXxKhltooO4xUuCBorl65a4EpnTalObqOigA=
 go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/6gtIk=
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=


### PR DESCRIPTION
## Applied fixes

**Simplify (S) — 5 applied**
- Remove dead `p.log = new(slog.Logger)` alloc immediately overwritten
- Extract `prepareCmd` helper eliminating three identical command-parse switch blocks across plugin.go / internal.go / init.go
- Concat replaces `fmt.Sprintf` for simple `key=value` env strings throughout
- Merge `case unix: / case tcp:` into `case unix, tcp:` in initFactory
- Deduplicate `user.Lookup` via new `userInfo()` helper; UID/GID delegate to it

**Modernize (M) — 3 applied**
- `slices.Clone` replaces manual `make+copy` for env slices
- `strings.Cut` replaces `strings.Split`+len check in `initFactory`
- `strconv.Atoi` replaces `strconv.ParseInt(..., 10, 32)` (plugin.go UID/GID)
- `os.ExpandEnv` replaces `os.Expand(v, os.Getenv)`

**Review / bugs (R) — 3 applied**
- Fix timer leak: `time.NewTimer` moved after `cmd.Start()` so no goroutine leaks when Start fails; add `defer timer.Stop()`
- Fix env ordering in `createProcess` (init.go): OS env is now prepended, config env appended — matching the main worker path so user-supplied env takes precedence over inherited OS env
- Fix error log in `GID()` that referenced `cfg.Group` instead of `cfg.User`

## Deps

`go get -u all && go mod tidy` in root and `tests/`; `go work sync`. Root `go.mod` had no version changes; `tests/go.sum` gained two new otel checksum entries.

